### PR TITLE
fixed uart_getc in zedboard

### DIFF
--- a/src/boards/zedboard/zynq_uart.c
+++ b/src/boards/zedboard/zynq_uart.c
@@ -178,7 +178,7 @@ uint32_t uart_getc(uint8_t uart_id){
 	uint32_t data = 0;
 
 	/* Wait until RxFIFO is filled up to the trigger level */
-	while(!ptr_uart->ch_status & UART_CH_STATUS_RTRIG);
+	while(!(char)(ptr_uart->ch_status & UART_CH_STATUS_RTRIG));
 
 	data = ptr_uart->tx_rx_fifo;
 


### PR DESCRIPTION
The uart_getc function was not blocking. This one line change fixes it.